### PR TITLE
Switch content retrieval to https.

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -6,12 +6,12 @@
         var disqus_shortname = '{{ site.disqus_shortname }}';
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>
-      <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-      <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+      <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+      <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
     </div>
   </div>
 </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -15,8 +15,8 @@
   /** You could use other style sheets or sassify 
   existing sheets like bootstrap or foundation **/
   @import "{{ site.baseurl }}/css/bootstrap.min.css";
-  @import "http://fonts.googleapis.com/css?family=Lato";
-  @import url(http://fonts.googleapis.com/css?family=Droid+Sans);
+  @import "https://fonts.googleapis.com/css?family=Lato";
+  @import url(https://fonts.googleapis.com/css?family=Droid+Sans);
   @import "{{ site.baseurl }}/css/chimad.css";
   @import "{{ site.baseurl }}/css/hexbin.css";
 </style>


### PR DESCRIPTION
Fix #29

Switch content retrieval to use https to avoid mixed content
errors. See
https://developer.mozilla.org/en-US/docs/Security/MixedContent.