### PR TITLE
regroup by complexity of state

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -28,7 +28,7 @@ the environment required to serve the site, use the following
 commands.
 
     $ sudo apt-get update
-    $ sudo apt-get install ruby
+    $ sudo apt-get install ruby nodejs
     $ sudo gem install jekyll jekyll-coffeescript
 
 Then clone the GitHub repository.
@@ -39,7 +39,8 @@ Then clone the GitHub repository.
 
 
 At this point [Jekyll][JEKYLL] should be serving the site. Go to
-`http://localhost:4000/chimad-phase-field` to view the site.
+[`http://localhost:4000/chimad-phase-field`](http://localhost:4000/chimad-phase-field),
+or the link [Jekyll][JEKYLL] provides on the terminal, to view the site.
 
 ## Add a New Phase Field Code
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -10,10 +10,19 @@ alt="Travis CI">
 </a>
 </p>
 
-## Overview
+# Overview
 
 The following guide is an overview on how to update the site for each
-particular element.  The site is tested on
+particular element. Many of these tasks require that you have an
+account on [GitHub][GITHUB]. Tasks are grouped below according to
+where you should edit the site: on the
+[running website](https://pages.nist.gov/chimad-phase-field), on the
+[master GitHub repository]({{ site.links.github }})
+or your personal
+[fork](https://help.github.com/articles/fork-a-repo/),
+or on your local machine.
+
+The site is tested on
 [Travis CI](https://travis-ci.org/usnistgov/chimad-phase-field) using
 [HTMLProofer][HTMLPROOFER], which automatically checks the site for
 errors. The [`.travis.yml`][TRAVISYML] file contains everything
@@ -21,35 +30,45 @@ required to build the site. Note that if the instructions below and
 the [`.travis.yml`][TRAVISYML] are not synced then the build outlined
 in the [`travis.yml`][TRAVISYML] should be used.
 
-## Build and Serve the Site
+## Update the Community Page
 
-The site uses the [Jekyll][JEKYLL] static web site generator. To build
-the environment required to serve the site, use the following
-commands.
+An instance of this Web site is hosted at
+[NIST](https://pages.nist.gov/chimad-phase-field).
+The [community page](https://pages.nist.gov/chimad-phase-field/community/)
+supports dynamic additions using Google
+Forms. Google Forms stores the data in a Google Docs spreadsheet. The
+link for the spreadsheet is stored in the [`_config.yaml`]({{
+site.links.github }}/blob/nist-pages/_config.yml) file under
+`links.members`. Currently the following fields are required in the
+form with the exact string matches.
 
-    $ sudo apt-get update
-    $ sudo apt-get install ruby nodejs
-    $ sudo gem install jekyll jekyll-coffeescript
+    - Name
+    - "Bio (one or two sentences)"
+    - URL
+    - Email
+    - "Home Page"
+    - "Twitter Handle"
+    - "GitHub Handle"
+    - "Other Links"
 
-Then clone the GitHub repository.
+## Updates on GitHub
 
-    $ git clone https://github.com/usnistgov/chimad-phase-field.git
-    $ cd chimad-phase-field
-    $ jekyll serve
+Several common tasks can be accomplished on [GitHub][GITHUB]
+by editing files
+[in-place](https://help.github.com/articles/editing-files-in-another-user-s-repository/).
+Doing so will automatically fork the repository to your
+[GitHub][GITHUB] account and submit a pull request to update the
+[master GitHub repository]({{ site.links.github }})
+with your content.
 
-
-At this point [Jekyll][JEKYLL] should be serving the site. Go to
-[`http://localhost:4000/chimad-phase-field`](http://localhost:4000/chimad-phase-field),
-or the link [Jekyll][JEKYLL] provides on the terminal, to view the site.
-
-## Add a New Phase Field Code
+### Add a New Phase Field Code
 
 To add a new phase field code to the list of codes on the front page,
 follow the [submission instructions]({{ site.baseurl
 }}/submit_a_new_code) on the main site. [Jekyll][JEKYLL] will
 automatically rebuild the site after `codes.yaml` is edited.
 
-## Add a new workshop
+### Add a new workshop
 
 To add a new workshop edit the [`workshop.yaml`]({{ site.links.github
 }}/blob/nist-pages/data/workshops.yaml) file. The following fields need to
@@ -74,25 +93,39 @@ be included for each entry.
 For each of the `icon_links`, the `type` field must correspond to a
 [Materialize icon](https://material.io/icons/).
 
-## Update the Community Page
+## Updates on Your Local machine
 
-The community page supports dynamic additions using Google
-Forms. Google Forms stores the data in a Google Docs spreadsheet. The
-link for the spreadsheet is stored in the [`_config.yaml`]({{
-site.links.github }}/blob/nist-pages/_config.yml) file under
-`links.members`. Currently the following fields are required in the
-form with the exact string matches.
+Some tasks involve adding new files or rebuilding existing ones. These
+are best done on your local machine, on a
+[clone of your fork](https://guides.github.com/activities/forking/)
+of the
+[master GitHub repository]({{ site.links.github }}).
+You are encouraged to serve a local version of the site for testing before
+[pushing your commits](https://help.github.com/articles/pushing-to-a-remote/)
+and issuing a
+[pull request](https://help.github.com/articles/creating-a-pull-request/).
 
-    - Name
-    - "Bio (one or two sentences)"
-    - URL
-    - Email
-    - "Home Page"
-    - "Twitter Handle"
-    - "GitHub Handle"
-    - "Other Links"
+### Build and Serve the Site
 
-## Update and Build the Hexbin
+The site uses the [Jekyll][JEKYLL] static web site generator. To build
+the environment required to serve the site, use the following
+commands.
+
+    $ sudo apt-get update
+    $ sudo apt-get install ruby nodejs
+    $ sudo gem install jekyll jekyll-coffeescript
+
+Then clone your fork of the GitHub repository.
+
+    $ git clone https://github.com/your_GitHub_account/chimad-phase-field.git
+    $ cd chimad-phase-field
+    $ jekyll serve
+
+At this point [Jekyll][JEKYLL] should be serving the site. Go to
+[`http://localhost:4000/chimad-phase-field`](http://localhost:4000/chimad-phase-field),
+or the link [Jekyll][JEKYLL] provides on the terminal, to view the site.
+
+### Update and Build the Hexbin
 
 To build the Hexbin, a Python environment is required. To setup the
 environment use [Conda][CONDA].
@@ -110,7 +143,8 @@ Create an environment with the required packages
     $ conda install progressbar2
 
 Update the data in the [`hexbin.yaml`]({{ site.links.github
-}}/blob/nist-pages/data/hexbin.yaml) file. The following format is used for each entry.
+}}/blob/nist-pages/data/hexbin.yaml) file. The following format is
+used for each entry.
 
     - image: http://www.mem.drexel.edu/ysun/files/density.png
       url: http://www.mem.drexel.edu/ysun/Solidification.htm
@@ -118,7 +152,6 @@ Update the data in the [`hexbin.yaml`]({{ site.links.github
       description: >-
         Phase-Field Simulation of Solidification (Collaborator:
         Prof. Christoph Beckermann, University of Iowa)
-
 The `url` field is the page that describes the image or the work
 associated with the image.  After updating rebuild the Hexbin.
 
@@ -126,7 +159,7 @@ associated with the image.  After updating rebuild the Hexbin.
 
 [Jekyll][JEKYLL] should automatically update the site.
 
-## Add a Jupyter Notebook
+### Add a Jupyter Notebook
 
 A lot of the site is built using Jupyter Notebooks. To render the
 notebooks as HTML, first generate the Python environment outlined
@@ -145,7 +178,7 @@ render it on the site. For example, a notebook in the base directory
 named `my_notebook.ipynb` will be rendered at
 `http://localhost:4000/chimad-phase-field/my_notebook.ipynb`.
 
-## Add a new Benchmark Problem
+### Add a new Benchmark Problem
 
 To add a new benchmark problem include a notebook describing the new
 problem and then link to it via the [`benchmarks.yaml`]({{
@@ -157,7 +190,7 @@ the following fields.
       description: Test the diffusion of a solute in a matrix.
       image: http://www.comsol.com/model/image/2054/big.png
 
-## Testing
+### Testing
 
 The site can be tested at the command line using
 [HTMLProofer][HTMLPROOFER]. This validates the generated HTML
@@ -189,4 +222,5 @@ correctly.
 [TRAVISYML]: {{ site.links.github }}/blob/nist-pages/.travis.yml
 [CONDA]: http://conda.pydata.org/docs/index.html
 [JEKYLL]: https://jekyllrb.com
+[GITHUB]: https://github.com
 [HTMLPROOFER]: https://github.com/gjtorikian/html-proofer


### PR DESCRIPTION
Users may want to add their name to the list, update the Web site without having to clone the repository, or build a test version of the site offline. Starting off with "Build and Serve the Site" may scare people off, so I've subjectively grouped and ordered the update tasks by increasing complexity. The first task requires no state of the user (change occurs behind the scenes). The second group of tasks can be accomplished on GitHub, producing some changes to the user's GitHub account. The final group requires cloning a fork to the local machine. Some context is provided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/chimad-phase-field/153)
<!-- Reviewable:end -->
