### PR TITLE
Enable memory to be given in Bytes

### DIFF
--- a/_data/charts/6a0_memory.json
+++ b/_data/charts/6a0_memory.json
@@ -133,7 +133,7 @@
       "transform": [],
       "values": [
         {
-          "memory_usage": 800000000.0,
+          "memory_usage": 781250.0,
           "time_ratio": 0.8080808080808081
         }
       ]

--- a/_data/simulations.py
+++ b/_data/simulations.py
@@ -147,7 +147,8 @@ def filter_memory_data(yaml_data):
         """
         unit_map = dict(GB=1048576.,
                         KB=1.,
-                        MB=1024.)
+                        MB=1024.,
+                        B=1. / 1024.)
         if isinstance(data, dict):
             data_ = data
         else:

--- a/_data/simulations/inl_moose_6a/meta.yaml
+++ b/_data/simulations/inl_moose_6a/meta.yaml
@@ -51,6 +51,6 @@ data:
         sim_time: '400'
   - name: memory_usage
     values:
-      - unit: KB
+      - unit: B
         value: '800000000'
 date: 1501620081


### PR DESCRIPTION
Enable memory to be given in Bytes and fix wrong memory unit in
simulation "inl_moose_6a".