### PR TITLE
Jekyll uses "plugins" instead of "gems" in config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -23,4 +23,4 @@ links:
 
 title: CHiMaD Phase Field
 
-gems: [jekyll-coffeescript]
+plugins: [jekyll-coffeescript]


### PR DESCRIPTION
Fix #498