### PR TITLE
Larger headshots on community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -27,8 +27,7 @@ comment: >-
       {% for item in site.data.community %}
         <div class="col s4">
           <div class="card small light-green lighten-4">
-            <div class="card-content"
-                 style="max-height: 95%">
+            <div class="card-content">
               <span class="card-title">
                 <a href="{{ item.home }}"
                    target="_blank"
@@ -38,7 +37,6 @@ comment: >-
               </span>
 
               <img class="circle"
-                   style="height: 40px; width: 40px; margin-left: 10px;"
                    src="{{ item.avatar }}"
                    alt="">
 
@@ -46,18 +44,16 @@ comment: >-
               <a href="mailto:{{ item.email }}"
                  target="blank_"
                  title="email">
-                <i class="small material-icons"
-                   style="font-size: 20px">
+                <i class="small material-icons">
                    email
                 </i>
               </a>
               <a href="https://github.com/{{ item.github_id }}"
                  target="blank_"
                  title="github">
-                <i class="small material-icons"
-                   style="font-size: 20px">
-                  <img style="width: 20px; height: 20px;"
-                       src="{{ site.baseurl }}/images/github-blue.svg"
+                <i class="small material-icons">
+                  <img src="{{ site.baseurl }}/images/github-blue.svg"
+                       class="github"
                        alt="github">
                 </i>
               </a>
@@ -65,11 +61,10 @@ comment: >-
                 <a href="https://twitter.com/{{ item.twitter }}"
                    target="blank_"
                    title="twitter">
-                  <i class="small material-icons"
-                     style="font-size: 20px">
-                    <img style="width: 20px; height: 20px;"
-                         src="{{ site.baseurl }}/images/twitter-blue.svg"
-                         alt="twitter">
+                  <i class="small material-icons">
+                    <img src="{{ site.baseurl }}/images/twitter-blue.svg"
+                         alt="twitter"
+                         class="github">
                   </i>
                 </a>
               {% endif %}

--- a/css/chimad.css
+++ b/css/chimad.css
@@ -163,3 +163,23 @@ table.striped tbody tr:nth-child(2n+1) {
     padding-left: 0px;
     margin-left: 50px;
 }
+
+.card.small .card-content {
+    max-height: 95%;
+}
+
+.circle {
+    height: 70px;
+    width: 70px;
+    margin-left: 10px;
+    object-fit: cover;
+}
+
+.small .material-icons {
+    font-size: 20px;
+}
+
+.github {
+    width: 20px;
+    height: 20px;
+}


### PR DESCRIPTION
Increase size of headshot from 40px to 70px.

 - Ensure that aspect ratio is maintained

 - Move all styling to CSS

Fix #497