### PR TITLE
Stop using redirect-from

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,6 +21,6 @@ links:
 
 title: CHiMaD Phase Field
 
-plugins: [jekyll-coffeescript, jekyll-redirect-from]
+plugins: [jekyll-coffeescript]
 
 admin_email: 'chimad-phase-field-admin@list.nist.gov'

--- a/_layouts/redirected.html
+++ b/_layouts/redirected.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="canonical" href="{{ page.redirect_to }}"/>
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
+<meta http-equiv="refresh" content="0;url={{ page.redirect_to }}" />
+</head>
+<body>
+    <h1>Redirecting...</h1>
+      <a href="{{ page.redirect_to }}">Click here if you are not redirected.<a>
+      <script>location='{{ page.redirect_to }}'</script>
+</body>
+</html>

--- a/benchmarks/benchmark1.ipynb.md
+++ b/benchmarks/benchmark1.ipynb.md
@@ -1,11 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark1a.1.ipynb/
-  - /benchmarks/benchmark1b.1.ipynb/
-  - /benchmarks/benchmark1c.1.ipynb/
-  - /benchmarks/benchmark1d.1.ipynb/
 ---
 
 {% include_relative benchmark1.ipynb.raw.html %}

--- a/benchmarks/benchmark1a.1.ipynb.md
+++ b/benchmarks/benchmark1a.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark1.ipynb/
+---

--- a/benchmarks/benchmark1b.1.ipynb.md
+++ b/benchmarks/benchmark1b.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark1.ipynb/
+---

--- a/benchmarks/benchmark1c.1.ipynb.md
+++ b/benchmarks/benchmark1c.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark1.ipynb/
+---

--- a/benchmarks/benchmark1d.1.ipynb.md
+++ b/benchmarks/benchmark1d.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark1.ipynb/
+---

--- a/benchmarks/benchmark2.ipynb.md
+++ b/benchmarks/benchmark2.ipynb.md
@@ -1,11 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark2a.1.ipynb/
-  - /benchmarks/benchmark2b.1.ipynb/
-  - /benchmarks/benchmark2c.1.ipynb/
-  - /benchmarks/benchmark2d.1.ipynb/
 ---
 
 {% include_relative benchmark2.ipynb.raw.html %}

--- a/benchmarks/benchmark2a.1.ipynb.md
+++ b/benchmarks/benchmark2a.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark2.ipynb/
+---

--- a/benchmarks/benchmark2b.1.ipynb.md
+++ b/benchmarks/benchmark2b.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark2.ipynb/
+---

--- a/benchmarks/benchmark2c.1.ipynb.md
+++ b/benchmarks/benchmark2c.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark2.ipynb/
+---

--- a/benchmarks/benchmark2d.1.ipynb.md
+++ b/benchmarks/benchmark2d.1.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark2.ipynb/
+---

--- a/benchmarks/benchmark3a.0.ipynb.md
+++ b/benchmarks/benchmark3a.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem1.ipynb/
+---

--- a/benchmarks/benchmark3b.0.ipynb.md
+++ b/benchmarks/benchmark3b.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem1.ipynb/
+---

--- a/benchmarks/benchmark3c.0.ipynb.md
+++ b/benchmarks/benchmark3c.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem1.ipynb/
+---

--- a/benchmarks/benchmark4a.0.ipynb.md
+++ b/benchmarks/benchmark4a.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem2.ipynb/
+---

--- a/benchmarks/benchmark4b.0.ipynb.md
+++ b/benchmarks/benchmark4b.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem2.ipynb/
+---

--- a/benchmarks/benchmark4c.0.ipynb.md
+++ b/benchmarks/benchmark4c.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../hackathons/hackathon2/problem2.ipynb/
+---

--- a/benchmarks/benchmark5-hackathon.ipynb.md
+++ b/benchmarks/benchmark5-hackathon.ipynb.md
@@ -1,10 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark5a.0.ipynb/
-  - /benchmarks/benchmark5b.0.ipynb/
-  - /benchmarks/benchmark5c.0.ipynb/
 ---
 
 {% include_relative benchmark5-hackathon.ipynb.raw.html %}

--- a/benchmarks/benchmark5a.0.ipynb.md
+++ b/benchmarks/benchmark5a.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark5-hackathon.ipynb/
+---

--- a/benchmarks/benchmark5b.0.ipynb.md
+++ b/benchmarks/benchmark5b.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark5-hackathon.ipynb/
+---

--- a/benchmarks/benchmark5c.0.ipynb.md
+++ b/benchmarks/benchmark5c.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark5-hackathon.ipynb/
+---

--- a/benchmarks/benchmark6-hackathon.ipynb.md
+++ b/benchmarks/benchmark6-hackathon.ipynb.md
@@ -1,10 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark6a.0.ipynb/
-  - /benchmarks/benchmark6b.0.ipynb/
-  - /benchmarks/benchmark6c.0.ipynb/
 ---
 
 {% include_relative benchmark6-hackathon.ipynb.raw.html %}

--- a/benchmarks/benchmark6a.0.ipynb.md
+++ b/benchmarks/benchmark6a.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark6-hackathon.ipynb/
+---

--- a/benchmarks/benchmark6b.0.ipynb.md
+++ b/benchmarks/benchmark6b.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark6-hackathon.ipynb/
+---

--- a/benchmarks/benchmark6c.0.ipynb.md
+++ b/benchmarks/benchmark6c.0.ipynb.md
@@ -1,0 +1,4 @@
+---
+layout: redirected
+redirect_to: ../../benchmarks/benchmark6-hackathon.ipynb/
+---

--- a/hackathons/hackathon2/problem1.ipynb.md
+++ b/hackathons/hackathon2/problem1.ipynb.md
@@ -1,10 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark3a.0.ipynb/
-  - /benchmarks/benchmark3b.0.ipynb/
-  - /benchmarks/benchmark3c.0.ipynb/
 ---
 
 {% include_relative problem1.ipynb.raw.html %}

--- a/hackathons/hackathon2/problem2.ipynb.md
+++ b/hackathons/hackathon2/problem2.ipynb.md
@@ -1,10 +1,6 @@
 ---
 title: ""
 layout: ipython
-redirect_from:
-  - /benchmarks/benchmark4a.0.ipynb/
-  - /benchmarks/benchmark4b.0.ipynb/
-  - /benchmarks/benchmark4c.0.ipynb/
 ---
 
 {% include_relative problem2.ipynb.raw.html %}


### PR DESCRIPTION
Address #553

Remove usage of the redirect-from gem. It appears that redirect-from
doesn't work on pages.nist.gov although it should work. Reverting to
using a simple redirect page for redirections, a less sophisticated
option but doesn't reply a plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/usnistgov/chimad-phase-field/555)
<!-- Reviewable:end -->
